### PR TITLE
Fixing Python bindings build

### DIFF
--- a/python/bindings/bind_oot_file.py
+++ b/python/bindings/bind_oot_file.py
@@ -19,9 +19,7 @@ parser.add_argument(
     '--filename', help="File to be parsed")
 
 parser.add_argument(
-    '--defines', help='Set additional defines for precompiler', default=(), nargs='*')
-parser.add_argument(
-    '--include', help='Additional Include Dirs, separated', default=(), nargs='*')
+    '--include', help='Additional Include Dirs, separated', default=(), nargs='+')
 
 parser.add_argument(
     '--status', help='Location of output file for general status (used during cmake)', default=None

--- a/python/bindings/docstrings/source_pydoc_template.h
+++ b/python/bindings/docstrings/source_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *

--- a/python/bindings/source_python.cc
+++ b/python/bindings/source_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d1a3d9ea3d815fe4f18acc3eef21f1b6)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8eed9451c1834118c28118da45bd358e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -332,6 +332,7 @@ void bind_source(py::module& m)
             py::arg("enabled"),
             D(source,set_biast)
         )
+
 
         .def("get_biast",&source::get_biast,
             D(source,get_biast)


### PR DESCRIPTION
When trying to build the Python bindings, this error occurs:

<details>
<summary>Stacktrace</summary>
```
In file included from ./gr-osmosdr/build/python/bindings/source_pydoc.h:9,
                 from ./gr-osmosdr/python/bindings/source_python.cc:28:
./gr-osmosdr/python/bindings/source_python.cc: In function ‘void bind_source(pybind11::module&)’:
./gr-osmosdr/build/python/bindings/pydoc_macros.h:11:28: error: ‘__doc_osmosdr_source_set_biast’ was not declared in this scope; did you mean ‘__doc_osmosdr_source_set_gain_1’?
   11 | #define __DOC3(n1, n2, n3) __doc_##n1##_##n2##_##n3
      |                            ^~~~~~
./gr-osmosdr/build/python/bindings/pydoc_macros.h:4:21: note: in definition of macro ‘__EXPAND’
    4 | #define __EXPAND(x) x
      |                     ^
./gr-osmosdr/build/python/bindings/pydoc_macros.h:4:21: note: in expansion of macro ‘__DOC3’
./gr-osmosdr/build/python/bindings/pydoc_macros.h:17:27: note: in expansion of macro ‘__EXPAND’
   17 | #define DOC(...) __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
      |                           ^~~~~~~~
./gr-osmosdr/build/python/bindings/pydoc_macros.h:8:22: note: in expansion of macro ‘__CAT1’
    8 | #define __CAT2(a, b) __CAT1(a, b)
      |                      ^~~~~~
./gr-osmosdr/build/python/bindings/pydoc_macros.h:17:36: note: in expansion of macro ‘__CAT2’
   17 | #define DOC(...) __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
      |                                    ^~~~~~
./gr-osmosdr/build/python/bindings/source_pydoc.h:10:16: note: in expansion of macro ‘DOC’
   10 | #define D(...) DOC(osmosdr, __VA_ARGS__ )
      |                ^~~
./gr-osmosdr/python/bindings/source_python.cc:333:13: note: in expansion of macro ‘D’
  333 |             D(source,set_biast)
      |             ^
./gr-osmosdr/build/python/bindings/pydoc_macros.h:11:28: error: ‘__doc_osmosdr_source_get_biast’ was not declared in this scope; did you mean ‘__doc_osmosdr_source_get_gain_1’?
   11 | #define __DOC3(n1, n2, n3) __doc_##n1##_##n2##_##n3
      |                            ^~~~~~
./gr-osmosdr/build/python/bindings/pydoc_macros.h:4:21: note: in definition of macro ‘__EXPAND’
    4 | #define __EXPAND(x) x
      |                     ^
./gr-osmosdr/build/python/bindings/pydoc_macros.h:4:21: note: in expansion of macro ‘__DOC3’
./gr-osmosdr/build/python/bindings/pydoc_macros.h:17:27: note: in expansion of macro ‘__EXPAND’
   17 | #define DOC(...) __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
      |                           ^~~~~~~~
./gr-osmosdr/build/python/bindings/pydoc_macros.h:8:22: note: in expansion of macro ‘__CAT1’
    8 | #define __CAT2(a, b) __CAT1(a, b)
      |                      ^~~~~~
./gr-osmosdr/build/python/bindings/pydoc_macros.h:17:36: note: in expansion of macro ‘__CAT2’
   17 | #define DOC(...) __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
      |                                    ^~~~~~
./gr-osmosdr/build/python/bindings/source_pydoc.h:10:16: note: in expansion of macro ‘DOC’
   10 | #define D(...) DOC(osmosdr, __VA_ARGS__ )
      |                ^~~
./gr-osmosdr/python/bindings/source_python.cc:337:13: note: in expansion of macro ‘D’
  337 |             D(source,get_biast)
      |             ^
make[2]: *** [python/bindings/CMakeFiles/osmosdr_python.dir/build.make:104: python/bindings/CMakeFiles/osmosdr_python.dir/source_python.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:414: python/bindings/CMakeFiles/osmosdr_python.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
</details>

This was caused by `python/bindings/docstrings/source_pydoc_template.h` getting updated at build time, changing a line to the following

```diff
-#define D(...) DOC(osmosdr, __VA_ARGS__ )
+#define D(...) DOC(gr,osmosdr, __VA_ARGS__ )
```

To avoid the file getting regenerated at build time, I updated the header file hash for `source.h`, so it sees the hash matches and doesn't try to generate the file.

I'm also undoing my change to `python/bindings/bind_oot_file.py` since it isn't actually needed.